### PR TITLE
Don't use error report as format

### DIFF
--- a/validate.el
+++ b/validate.el
@@ -165,7 +165,7 @@ indicate a failure."
   (let ((report (validate--check value schema)))
     (if report
         (unless noerror
-          (user-error report))
+          (user-error "%s" report))
       value)))
 
 ;;;###autoload


### PR DESCRIPTION
The second argument of "user-error" is a format string; we must not pass an arbitrary string in this place.

If a bad value contains a percentage sign, it'll end up in a "format" position through "report", causing a second failure about missing format arguments which masks the original error.

To prevent this use an explicit format and pass the "report" as format string argument.