### PR TITLE
Fixed a bug on validating boolean with value nil

### DIFF
--- a/validate.el
+++ b/validate.el
@@ -189,7 +189,7 @@ with `validate-value'. NOERROR is passed to `validate-value'."
   "Mark SYMBOL as a safe local if its custom type is obeyed."
   (put symbol 'safe-local-variable
        (lambda (val)
-         (validate-value val (custom-variable-type symbol) 'noerror))))
+         (or (validate-value val (custom-variable-type symbol) nil) t)
 
 (defmacro validate-setq (&rest svs)
   "Like `setq', but throw an error if validation fails.


### PR DESCRIPTION
Suppose we have a boolean variable `foo`
```elisp
(defcustom foo nil
  ".."
  :type 'boolean)

(setq foo nil)
(validate-mark-safe-local 'foo)
```
You'd expect that  `(validate-variable 'foo)` should return t.
But no, it returns its value, nil.

This commit works as this:

If the value is valid, `validate-value` form returns its value.  Regardless of the value, `(or VALUE t)` returns t

If the value is invalid, the error would be thrown.   And note that `safe-local-variable-p` is defined as
```elisp
(defun safe-local-variable-p (sym val)
  (or (member (cons sym val) safe-local-variable-values)
      (let ((safep (get sym 'safe-local-variable)))
        (and (functionp safep)
             ;; If the function signals an error, that means it
             ;; can't assure us that the value is safe.
             (with-demoted-errors (funcall safep val))))))
```
The error thrown by `validate-value` is demoted by `safe-local-variable-p`, and a nil is returned.